### PR TITLE
Add resize handle code

### DIFF
--- a/PantheonAddonFramework/UI/IAddonWindow.cs
+++ b/PantheonAddonFramework/UI/IAddonWindow.cs
@@ -11,6 +11,8 @@ public interface IAddonWindow
     void SetPosition(float newX, float newY);
 
     IAddonTextComponent AddTextComponent(string initialText);
+    IAddonWindow AddResizeHandle(int maxWidth, int maxHeight, int minWidth, int minHeight);
+    
     void Enable(bool enabled);
     void Destroy();
 }

--- a/PantheonAddonLoader/AddonComponents/CustomUI.cs
+++ b/PantheonAddonLoader/AddonComponents/CustomUI.cs
@@ -31,7 +31,8 @@ public class CustomUI : ICustomUI
         gameObject.layer = Layers.UI;
         
         var rectTransform = gameObject.AddComponent<RectTransform>();
-        rectTransform.anchoredPosition = new Vector2(0, 0);
+        rectTransform.pivot = new Vector2(0, 1);
+        rectTransform.anchoredPosition = new Vector2(-(initialSize.x / 2), initialSize.y / 2);
         rectTransform.sizeDelta = initialSize;
         
         var canvasRenderer = gameObject.AddComponent<CanvasRenderer>();
@@ -45,9 +46,6 @@ public class CustomUI : ICustomUI
 
         uiDraggable._windowPanel = uiWindowPanel;
         
-        var layout = gameObject.AddComponent<VerticalLayoutGroup>();
-        layout.padding = new RectOffset(14, 14, 14, 14);
-
         var image = gameObject.AddComponent<Image>();
         image.type = Image.Type.Sliced;
         image.sprite = imageToCopy.sprite;

--- a/PantheonAddonLoader/UI/AddonWindow.cs
+++ b/PantheonAddonLoader/UI/AddonWindow.cs
@@ -53,6 +53,26 @@ public class AddonWindow : IAddonWindow
         return new AddonTextComponent(textComponent);
     }
 
+    // TODO: Set this up from scratch instead of copying from an existing window
+    public IAddonWindow AddResizeHandle(int maxWidth, int maxHeight, int minWidth, int minHeight)
+    {
+        var mainChatWindow = UIChatWindows.Instance.mainWindow;
+        var resizeHandle = mainChatWindow.GetComponentInChildren<UIResizeHandle>();
+        
+        var resizeCopy = Object.Instantiate(resizeHandle, resizeHandle.transform.position, resizeHandle.transform.rotation, _rectTransform);
+        var copyHandle = resizeCopy.GetComponent<UIResizeHandle>();
+        copyHandle.ContainerRect = _rectTransform;
+        copyHandle.MaxSize = new Vector2(maxWidth, maxHeight);
+        copyHandle.MinSize = new Vector2(minWidth, minHeight);
+        
+        var copyRect = resizeCopy.GetComponent<RectTransform>();
+        copyRect.pivot = new Vector2(1, 0);
+        copyRect.sizeDelta = new Vector2(25, 25);
+        copyRect.anchoredPosition = new Vector2(-5, 4);
+        
+        return this;
+    }
+
     public void Enable(bool enabled)
     {
         _window.gameObject.SetActive(enabled);


### PR DESCRIPTION
Closes #8 

* Adds a resize handle to the bottom right of the window
* Centres windows on creation for now, setting pivot to `0, 1` for resizing
* Removed VerticalLayoutGroup from custom windows on creation, this should go on a child object instead

[Video.webm](https://github.com/user-attachments/assets/85dbe971-fac5-4bce-b9fe-f9aef69412ec)