### PR TITLE
Save and load preferences between sessions

### DIFF
--- a/PantheonAddonLoader/AddonLoader.cs
+++ b/PantheonAddonLoader/AddonLoader.cs
@@ -1,4 +1,3 @@
-using Il2CppInterop.Runtime.Injection;
 using MelonLoader;
 using PantheonAddonFramework;
 using PantheonAddonLoader.AddonManagement;
@@ -24,6 +23,13 @@ public class AddonLoader : MelonMod
             Directory.CreateDirectory(AddonsFolderPath);
         }
         
+        // MelonLoader's OnApplicationQuit doesn't fire unless the game shuts down cleanly
+        // e.g., it does not fire if the console window is closed, so instead listen for ProcessExit to save
+        // when closed via the console window
+        AppDomain.CurrentDomain.ProcessExit += (s, e) => 
+        {
+            MelonPreferences.Save();
+        };
         LoadAddons();
     }
 


### PR DESCRIPTION
Closes #12
Backed by MelonPreferences.
Saves on application exit, using `AppDomain` instead of MelonLoader's `OnApplicationQuit` because it doesn't fire if e.g., the game is closed by closing the MelonLoader command prompt window.