### PR TITLE
Improvements for config saving and loading

### DIFF
--- a/PantheonAddonFramework/Addon.cs
+++ b/PantheonAddonFramework/Addon.cs
@@ -17,7 +17,6 @@ public abstract class Addon : IDisposable
     public ILifecycleEvents LifecycleEvents { get; set; }
     
     public string Name { get; set; }
-    public bool Enabled { get; set; }
     public string Author { get; set; }
     public string Description { get; set; }
 

--- a/PantheonAddonLoader/AddonManagement/AddonActivator.cs
+++ b/PantheonAddonLoader/AddonManagement/AddonActivator.cs
@@ -2,6 +2,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using MelonLoader;
 using PantheonAddonFramework;
+using PantheonAddonFramework.Configuration;
 using PantheonAddonLoader.AddonComponents;
 
 namespace PantheonAddonLoader.AddonManagement;
@@ -13,7 +14,7 @@ internal static class ScriptActivator
         var expression = Expression.New(addonType);
         var lambda = Expression.Lambda<Func<object>>(expression);
         var compiled = lambda.Compile();
-        
+
         if (compiled() is not Addon instance)
         {
             return null;
@@ -26,7 +27,7 @@ internal static class ScriptActivator
             MelonLogger.Error($"Failed to load {addonType.Name}, make sure it has a {nameof(scriptAttribute)}");
             return null;
         }
-        
+
         RegisterDependencies(instance);
 
         instance.Name = scriptAttribute.Name;
@@ -34,10 +35,53 @@ internal static class ScriptActivator
         instance.Description = scriptAttribute.Description;
 
         instance.OnCreate();
-        
+
+        SetupConfiguration(instance);
+
         MelonLogger.Msg($"Loaded [{scriptAttribute.Author}] {scriptAttribute.Name}");
-        
+
         return instance;
+    }
+
+    private static void SetupConfiguration(Addon addon)
+    {
+        var configSection = MelonPreferences.CreateCategory(addon.Name);
+        var enabled = configSection.CreateEntry(addon.Name, true);
+        if (enabled.Value)
+        {
+            addon.Enable();
+        }
+        else
+        {
+            addon.Disable();
+        }
+
+        foreach (var configuration in addon.GetConfiguration())
+        {
+            switch (configuration)
+            {
+                case FloatConfigurationValue floatConfigurationValue:
+                    var floatEntry = configSection.CreateEntry(floatConfigurationValue.Name,
+                        floatConfigurationValue.InitialValue);
+                    floatConfigurationValue.OnValueChanged(floatEntry.Value);
+                    break;
+                case IntConfigurationValue intConfigurationValue:
+                    var intEntry =
+                        configSection.CreateEntry(intConfigurationValue.Name, intConfigurationValue.InitialValue);
+                    intConfigurationValue.OnValueChanged(intEntry.Value);
+                    break;
+                case BoolConfigurationValue boolConfigurationValue:
+                    var boolEntry = configSection.CreateEntry(boolConfigurationValue.Name,
+                        boolConfigurationValue.InitialValue);
+                    boolConfigurationValue.OnValueChanged(boolEntry.Value);
+                    break;
+                case PicklistConfigurationValue picklistConfigurationValue:
+                    var picklistEntry = configSection.CreateEntry(picklistConfigurationValue.Name,
+                        picklistConfigurationValue.InitialIndex);
+                    picklistConfigurationValue.OnSelectionChanged(picklistEntry.Value);
+                    break;
+            }
+        }
     }
 
     private static void RegisterDependencies(Addon instance)
@@ -46,7 +90,7 @@ internal static class ScriptActivator
         instance.Keyboard = new Keyboard();
         instance.Macros = new Macros();
         instance.CustomUI = new CustomUI();
-        
+
         instance.WindowPanelEvents = AddonLoader.WindowPanelEvents;
         instance.LocalPlayerEvents = AddonLoader.LocalPlayerEvents;
         instance.PlayerEvents = AddonLoader.PlayerEvents;

--- a/PantheonAddonLoader/AddonManagement/AddonActivator.cs
+++ b/PantheonAddonLoader/AddonManagement/AddonActivator.cs
@@ -32,13 +32,10 @@ internal static class ScriptActivator
         instance.Name = scriptAttribute.Name;
         instance.Author = scriptAttribute.Author;
         instance.Description = scriptAttribute.Description;
-        instance.Enabled = true;
 
         instance.OnCreate();
         
         MelonLogger.Msg($"Loaded [{scriptAttribute.Author}] {scriptAttribute.Name}");
-        
-        instance.Enable();
         
         return instance;
     }

--- a/PantheonAddonLoader/Hooks/UISettingsHooks.cs
+++ b/PantheonAddonLoader/Hooks/UISettingsHooks.cs
@@ -137,8 +137,6 @@ public class UISettingsHooks
             configuration.OnSelectionChanged(dropDown.value);
             entry.Value = dropDown.value;
         })));
-        
-        dropDown.onValueChanged.Invoke(dropDown.value);
     }
 
     private static void SetupCustomToggle(Addon addon, BoolConfigurationValue configuration, Transform parent, Transform buttonToCopy)
@@ -166,8 +164,6 @@ public class UISettingsHooks
             configuration.OnValueChanged(toggleComp.isOn);
             entry.Value = toggleComp.isOn;
         })));
-
-        toggleComp.onValueChanged.Invoke(toggleComp.isOn);
     }
 
     private static void SetupCustomSlider(Addon addon, FloatConfigurationValue configuration, Transform parent, Transform sliderToCopy)
@@ -200,8 +196,6 @@ public class UISettingsHooks
             
             entry.Value = MathF.Round(sliderComp.value, 1);
         })));
-        
-        sliderComp.onValueChanged.Invoke(MathF.Round(sliderComp.value, 1));
         
         var handleObject = sliderObj.GetChild(2).GetChild(0);
         var tooltip = handleObject.GetComponent<UITooltip>();
@@ -241,8 +235,6 @@ public class UISettingsHooks
             configEntry.Value = (int)sliderComp.value;
         })));
 
-        sliderComp.onValueChanged.Invoke(configEntry.Value);
-        
         var handleObject = sliderObj.GetChild(2).GetChild(0);
         var tooltip = handleObject.GetComponent<UITooltip>();
         tooltip.TooltipHeadingText = configuration.Name;

--- a/PantheonAddonLoader/Hooks/UISettingsHooks.cs
+++ b/PantheonAddonLoader/Hooks/UISettingsHooks.cs
@@ -126,8 +126,8 @@ public class UISettingsHooks
             });
         }
 
-        var category = MelonPreferences.CreateCategory(addon.Name);
-        var entry = category.CreateEntry(configuration.Name, configuration.InitialIndex);
+        var category = MelonPreferences.GetCategory(addon.Name);
+        var entry = category.GetEntry<int>(configuration.Name);
         
         dropDown.value = entry.Value;
         
@@ -154,8 +154,8 @@ public class UISettingsHooks
         
         var toggleComp = copy.GetComponent<Toggle>();
         
-        var category = MelonPreferences.CreateCategory(addon.Name);
-        var entry = category.CreateEntry(configuration.Name, configuration.InitialValue);
+        var category = MelonPreferences.GetCategory(addon.Name);
+        var entry = category.GetEntry<bool>(configuration.Name);
         
         toggleComp.isOn = entry.Value;
         toggleComp.onValueChanged.RemoveAllListeners();
@@ -182,9 +182,10 @@ public class UISettingsHooks
         sliderComp.maxValue = configuration.MaxValue;
         sliderComp.wholeNumbers = false;
         
-        var category = MelonPreferences.CreateCategory(addon.Name);
-        var entry = category.CreateEntry(configuration.Name, configuration.InitialValue);
+        var category = MelonPreferences.GetCategory(addon.Name);
+        var entry = category.GetEntry<float>(configuration.Name);
         sliderComp.value = entry.Value;
+        textComp.text = $"{configuration.Name} - {sliderComp.value:F1}";
         
         sliderComp.onValueChanged.RemoveAllListeners();
         sliderComp.onValueChanged.AddCall(new InvokableCall(new Action(() =>
@@ -220,10 +221,11 @@ public class UISettingsHooks
         sliderComp.maxValue = configuration.MaxValue;
         sliderComp.wholeNumbers = true;
         
-        var category = MelonPreferences.CreateCategory(addon.Name);
-        var configEntry = category.CreateEntry(configuration.Name, configuration.InitialValue);
+        var category = MelonPreferences.GetCategory(addon.Name);
+        var configEntry = category.GetEntry<int>(configuration.Name);
         
         sliderComp.value = configEntry.Value;
+        textComp.text = $"{configuration.Name} - {sliderComp.value}";
         
         sliderComp.onValueChanged.RemoveAllListeners();
         sliderComp.onValueChanged.AddCall(new InvokableCall(new Action(() =>


### PR DESCRIPTION
Configuration is now created / read when an addon instance is activating, instead of when the settings UI is created. This will help with disposing addons in the future, as the settings UI is not recreated often.
Removed redundant `Enabled` property from addon. Addons can manage their own state via their own methods instead.
Addon::Enable and Addon::Disable are called appropriately as part of the instantiation.