### PR TITLE
Add Chat addon component for posting info messages

### DIFF
--- a/PantheonAddonFramework/Addon.cs
+++ b/PantheonAddonFramework/Addon.cs
@@ -10,6 +10,7 @@ public abstract class Addon : IDisposable
     public IKeyboard Keyboard { get; set; }
     public IMacros Macros { get; set; }
     public ICustomUI CustomUI { get; set; }
+    public IChat Chat { get; set; }
     
     public IWindowPanelEvents WindowPanelEvents { get; set; }
     public ILocalPlayerEvents LocalPlayerEvents { get; set; }

--- a/PantheonAddonFramework/AddonComponents/IChat.cs
+++ b/PantheonAddonFramework/AddonComponents/IChat.cs
@@ -1,0 +1,11 @@
+namespace PantheonAddonFramework.AddonComponents;
+
+public interface IChat
+{
+    /// <summary>
+    /// Adds a message to the chat that has the info chat type. This is visible only to the client.
+    /// If the user has filtered info messages, the message will not be displayed.
+    /// </summary>
+    /// <param name="message"></param>
+    void AddInfoMessage(string message);
+}

--- a/PantheonAddonLoader/AddonComponents/Chat.cs
+++ b/PantheonAddonLoader/AddonComponents/Chat.cs
@@ -1,0 +1,13 @@
+using Il2Cpp;
+using Il2CppPantheonPersist;
+using PantheonAddonFramework.AddonComponents;
+
+namespace PantheonAddonLoader.AddonComponents;
+
+public class Chat : IChat
+{
+    public void AddInfoMessage(string message)
+    {
+        UIChatWindows.Instance.PassMessage(message, ChatChannelType.Info);
+    }
+}

--- a/PantheonAddonLoader/AddonManagement/AddonActivator.cs
+++ b/PantheonAddonLoader/AddonManagement/AddonActivator.cs
@@ -90,6 +90,7 @@ internal static class ScriptActivator
         instance.Keyboard = new Keyboard();
         instance.Macros = new Macros();
         instance.CustomUI = new CustomUI();
+        instance.Chat = new Chat();
 
         instance.WindowPanelEvents = AddonLoader.WindowPanelEvents;
         instance.LocalPlayerEvents = AddonLoader.LocalPlayerEvents;


### PR DESCRIPTION
Only supports posting `Info` messages.
I went back and forth about whether to include this, but when an addon wants to display a message to the user, its only option is to use the `Logger` which will output to the console window. The user is unlikely to have that console window focused, or to tab back to it often. To avoid addons creating misleading messages, I don't think this will support other message types e.g., say/auction/out of character.

```csharp
private void OnPlayerEntered(IPlayer player)
{   
    Chat.AddInfoMessage("Testing a message from enhanced experience bar");
    ...etc
}
```

`Chat.

![image](https://github.com/user-attachments/assets/fabc4c97-689f-404c-b302-2daad15dce21)
