### PR TITLE
Load custom images from disk, add UI/IAddonImageComponent

### DIFF
--- a/PantheonAddonFramework/UI/IAddonImageComponent.cs
+++ b/PantheonAddonFramework/UI/IAddonImageComponent.cs
@@ -2,7 +2,7 @@ namespace PantheonAddonFramework.UI;
 
 public interface IAddonImageComponent
 {
-    void SetSprite(string filePath);
+    void SetSpriteFromFile(string filePath);
 
     void SetColour(byte r, byte g, byte b, byte a);
 

--- a/PantheonAddonFramework/UI/IAddonImageComponent.cs
+++ b/PantheonAddonFramework/UI/IAddonImageComponent.cs
@@ -1,0 +1,12 @@
+namespace PantheonAddonFramework.UI;
+
+public interface IAddonImageComponent
+{
+    void SetSprite(string filePath);
+
+    void SetColour(byte r, byte g, byte b, byte a);
+
+    void SetColour(float r, float g, float b, float a);
+
+    void SetSize(int width, int height);
+}

--- a/PantheonAddonFramework/UI/IAddonWindow.cs
+++ b/PantheonAddonFramework/UI/IAddonWindow.cs
@@ -10,6 +10,7 @@ public interface IAddonWindow
     void SetWidth(float newWidth);
     void SetPosition(float newX, float newY);
 
+    IAddonImageComponent AddImageComponent(string objectName);
     IAddonTextComponent AddTextComponent(string initialText);
     IAddonWindow AddResizeHandle(int maxWidth, int maxHeight, int minWidth, int minHeight);
     

--- a/PantheonAddonLoader/AddonLoader.cs
+++ b/PantheonAddonLoader/AddonLoader.cs
@@ -21,6 +21,8 @@ public class AddonLoader : MelonMod
     public static readonly LifecycleEvents LifecycleEvents = new();
     public static readonly ChatEvents ChatEvents = new();
 
+    public static readonly ICustomAssetManager CustomAssetManager = new CustomAssetManager();
+    
     public override void OnInitializeMelon()
     {
         if (!Directory.Exists(AddonsFolderPath))

--- a/PantheonAddonLoader/CustomAssetManager.cs
+++ b/PantheonAddonLoader/CustomAssetManager.cs
@@ -1,0 +1,43 @@
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using UnityEngine;
+using UnityEngine.Bindings;
+
+namespace PantheonAddonLoader;
+
+public class CustomAssetManager : ICustomAssetManager
+{
+    private Dictionary<string, Texture2D> _imageAssets = new();
+    
+    public Texture2D GetSprite(string filePath)
+    {
+        if (_imageAssets.TryGetValue(filePath, out var texture))
+        {
+            return texture;
+        }
+
+        texture = LoadTextureFromFile(filePath);
+        _imageAssets.Add(filePath, texture);
+        
+        return texture;
+    }
+
+    private static Texture2D LoadTextureFromFile(string filePath)
+    {
+        var imageAsBytes = File.ReadAllBytes(filePath);
+        var image = new Texture2D(2, 2);
+
+        unsafe
+        {
+            var intPtr = UnityEngine.Object.MarshalledUnityObject.MarshalNotNull(image);
+
+            fixed (byte* ptr = imageAsBytes)
+            {
+                var managedSpanWrapper = new ManagedSpanWrapper(ptr, imageAsBytes.Length);
+
+                ImageConversion.LoadImage_Injected(intPtr, ref managedSpanWrapper, false);
+            }
+        }
+
+        return image;
+    }
+}

--- a/PantheonAddonLoader/ICustomAssetManager.cs
+++ b/PantheonAddonLoader/ICustomAssetManager.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+namespace PantheonAddonLoader;
+
+public interface ICustomAssetManager
+{
+    Texture2D GetSprite(string filePath);
+}

--- a/PantheonAddonLoader/PantheonAddonLoader.csproj
+++ b/PantheonAddonLoader/PantheonAddonLoader.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>
@@ -343,9 +344,6 @@
       </Reference>
       <Reference Include="Unity.VisualEffectGraph.Runtime">
         <HintPath>$(GamePath)\MelonLoader\Il2CppAssemblies\Unity.VisualEffectGraph.Runtime.dll</HintPath>
-      </Reference>
-      <Reference Include="UnityEngine">
-        <HintPath>$(GamePath)\MelonLoader\Il2CppAssemblies\UnityEngine.dll</HintPath>
       </Reference>
       <Reference Include="UnityEngine.AccessibilityModule">
         <HintPath>$(GamePath)\MelonLoader\Il2CppAssemblies\UnityEngine.AccessibilityModule.dll</HintPath>

--- a/PantheonAddonLoader/UI/AddonImageComponent.cs
+++ b/PantheonAddonLoader/UI/AddonImageComponent.cs
@@ -1,0 +1,39 @@
+using PantheonAddonFramework.UI;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace PantheonAddonLoader.UI;
+
+public class AddonImageComponent : IAddonImageComponent
+{
+    private readonly ICustomAssetManager _customAssetManager;
+    private readonly Image _image;
+
+    public AddonImageComponent(Image image, ICustomAssetManager customAssetManager)
+    {
+        _customAssetManager = customAssetManager;
+        _image = image;
+    }
+
+    public void SetSprite(string filePath)
+    {
+        var texture = _customAssetManager.GetSprite(filePath);
+        
+        _image.sprite = Sprite.Create(texture, new Rect(0, 0, texture.width, texture.height), Vector2.zero);
+    }
+
+    public void SetColour(byte r, byte g, byte b, byte a)
+    {
+        _image.color = new Color32(r, g, b, a);
+    }
+
+    public void SetColour(float r, float g, float b, float a)
+    {
+        _image.color = new Color(r, g, b, a);
+    }
+
+    public void SetSize(int width, int height)
+    {
+        _image.rectTransform.sizeDelta = new Vector2(width, height);
+    }
+}

--- a/PantheonAddonLoader/UI/AddonImageComponent.cs
+++ b/PantheonAddonLoader/UI/AddonImageComponent.cs
@@ -15,7 +15,7 @@ public class AddonImageComponent : IAddonImageComponent
         _image = image;
     }
 
-    public void SetSprite(string filePath)
+    public void SetSpriteFromFile(string filePath)
     {
         var texture = _customAssetManager.GetSprite(filePath);
         

--- a/PantheonAddonLoader/UI/AddonWindow.cs
+++ b/PantheonAddonLoader/UI/AddonWindow.cs
@@ -2,6 +2,7 @@ using Il2Cpp;
 using Il2CppTMPro;
 using PantheonAddonFramework.UI;
 using UnityEngine;
+using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
 namespace PantheonAddonLoader.UI;
@@ -36,7 +37,17 @@ public class AddonWindow : IAddonWindow
     {
         _rectTransform.transform.position = new Vector2(newX, newY);
     }
-    
+
+    public IAddonImageComponent AddImageComponent(string objectName)
+    {
+        var go = new GameObject("Test");
+        go.transform.SetParent(_window.transform);
+
+        var imageComponent = go.AddComponent<Image>();
+
+        return new AddonImageComponent(imageComponent, AddonLoader.CustomAssetManager);
+    }
+
     public IAddonTextComponent AddTextComponent(string initialText)
     {
         var go = new GameObject("Test");


### PR DESCRIPTION
Closes #13 

Caches sprites loaded from disk in `ICustomAssetManager`.
Exposes `SetSpriteFromFile` in `IAddonImageComponent` to load textures from cache.