### PR TITLE
Add inventory and bank currency to Player

### DIFF
--- a/PantheonAddonFramework/Models/ICurrency.cs
+++ b/PantheonAddonFramework/Models/ICurrency.cs
@@ -1,0 +1,11 @@
+namespace PantheonAddonFramework.Models;
+
+public interface ICurrency
+{
+    byte Copper { get; }
+    byte Silver { get; }
+    byte Gold { get; }
+    byte Platinum { get; }
+    uint Mithril { get; }
+    long Total { get; }
+}

--- a/PantheonAddonFramework/Models/IPlayer.cs
+++ b/PantheonAddonFramework/Models/IPlayer.cs
@@ -3,6 +3,10 @@ namespace PantheonAddonFramework.Models;
 public interface IPlayer
 {
     IEntityStats Stats { get; }
+    
+    ICurrency InventoryCurrency { get; }
+    
+    ICurrency BankCurrency { get; }
 
     long CharacterId { get; }
     

--- a/PantheonAddonLoader/Models/BankCurrency.cs
+++ b/PantheonAddonLoader/Models/BankCurrency.cs
@@ -1,0 +1,21 @@
+using Il2Cpp;
+using PantheonAddonFramework.Models;
+
+namespace PantheonAddonLoader.Models;
+
+public class BankCurrency : ICurrency
+{
+    private readonly EntityBankCurrency.Logic _currency;
+
+    public BankCurrency(EntityBankCurrency.Logic currency)
+    {
+        _currency = currency;
+    }
+
+    public byte Copper => _currency.Current.Copper;
+    public byte Silver => _currency.Current.Silver;
+    public byte Gold => _currency.Current.Gold;
+    public byte Platinum => _currency.Current.Platinum;
+    public uint Mithril => _currency.Current.Mithril;
+    public long Total => _currency.Current.Total;
+}

--- a/PantheonAddonLoader/Models/Player.cs
+++ b/PantheonAddonLoader/Models/Player.cs
@@ -1,6 +1,5 @@
 using Il2Cpp;
 using Il2CppPantheonPersist;
-using PantheonAddonFramework;
 using PantheonAddonFramework.Models;
 
 namespace PantheonAddonLoader.Models;
@@ -9,13 +8,17 @@ public class Player : IPlayer
 {
     private readonly EntityPlayerGameObject _entityPlayerGameObject;
     public IEntityStats Stats { get; }
-    
+    public ICurrency InventoryCurrency { get; }
+    public ICurrency BankCurrency { get; }
+
     public Player(EntityPlayerGameObject entityPlayerGameObject)
     {
         _entityPlayerGameObject = entityPlayerGameObject;
         Stats = new EntityStats(_entityPlayerGameObject.Pools);
+        InventoryCurrency = new PlayerCurrency(_entityPlayerGameObject.Currency);
+        BankCurrency = new BankCurrency(_entityPlayerGameObject.BankCurrency);
     }
-    
+
     public long CharacterId => _entityPlayerGameObject.info.CharacterId;
     public string Name => _entityPlayerGameObject.info.DisplayName;
     public int Level => _entityPlayerGameObject.Experience.Level;

--- a/PantheonAddonLoader/Models/PlayerCurrency.cs
+++ b/PantheonAddonLoader/Models/PlayerCurrency.cs
@@ -1,0 +1,21 @@
+using Il2Cpp;
+using PantheonAddonFramework.Models;
+
+namespace PantheonAddonLoader.Models;
+
+public class PlayerCurrency : ICurrency
+{
+    private readonly EntityCurrency.Logic _currency;
+
+    public PlayerCurrency(EntityCurrency.Logic currency)
+    {
+        _currency = currency;
+    }
+
+    public byte Copper => _currency.Current.Copper;
+    public byte Silver => _currency.Current.Silver;
+    public byte Gold => _currency.Current.Gold;
+    public byte Platinum => _currency.Current.Platinum;
+    public uint Mithril => _currency.Current.Mithril;
+    public long Total => _currency.Current.Total;
+}


### PR DESCRIPTION
Adds `Total`, `Mithril`, `Platinum`, `Gold`, `Silver`, and `Copper` to the API on the `Player` class. For players other than the local player, this will be 0.

Tested in an example addon
```csharp
var inventory = _player.InventoryCurrency;
var bank = _player.BankCurrency;
Logger.Info($"Inventory has {inventory.Total} total, {inventory.Mithril}m, {inventory.Platinum}p, {inventory.Gold}g, {inventory.Silver}s, {inventory.Copper}c");
Logger.Info($"Bank has {bank.Total} total, {bank.Mithril}m, {bank.Platinum}p, {bank.Gold}g, {bank.Silver}s, {bank.Copper}c");
```